### PR TITLE
Update upstart script to match cronnelly's gist

### DIFF
--- a/support/upstart-config.conf
+++ b/support/upstart-config.conf
@@ -1,12 +1,17 @@
-description "{DOMAIN} {ENV}"
-author      "Tom Gallacher"
-
+author      "Michael Cronnelly"
+ 
+env NODE_ENV={ENV}
+env NODE_START=/var/application/{DOMAIN}/app.js
+env NODE_VERSION={NODE_VERSION}
+env PORT={PORT}
+ 
+setuid node
+env HOME=/home/node
+ 
 start on (local-filesystems and net-device-up IFACE=eth0)
 stop  on shutdown
-
+ 
 respawn                # restart when job dies
 respawn limit 5 60     # give up restart after 5 respawns in 60 seconds
-
-script
-  exec sudo -u {NODE_USER} NODE_ENV={ENV} PORT={PORT} /usr/local/bin/nave use {NODE_VERSION} node /var/application/{DOMAIN}/app.js >> /var/log/application/{DOMAIN}/node.log 2>&1
-end script
+ 
+exec /usr/local/bin/nave use $NODE_VERSION node $NODE_START


### PR DESCRIPTION
The current upstart script redirects log output in a way that we cannot automatically rotate. The changes proposed here would bring the upstart scripts for new Darkroom installs in line with what we use for other node processes.

See @cronnelly's gist: https://gist.github.com/cronnelly/5643792
