### PR TITLE
Use path.join() rather than string concat to ensure path validity.

### DIFF
--- a/endpoint/original.js
+++ b/endpoint/original.js
@@ -2,6 +2,7 @@ var config = require('con.figure')(require('../config')())
   , fileupload = require('fileupload').createFileUpload(config.paths.data())
   , mime = require('mime-magic')
   , restify = require('restify')
+  , path = require('path')
 
 module.exports = function (req, res, next) {
   res.set('X-Application-Method', 'Original Image')
@@ -10,7 +11,7 @@ module.exports = function (req, res, next) {
     if (err) {
       return next(new restify.ResourceNotFoundError('Not Found'))
     }
-    mime(config.paths.data() + file, function (err, type) {
+    mime(path.join(config.paths.data(), file), function (err, type) {
       if (err) return next(err)
       res.set('Content-Type', type)
       res.write(data)


### PR DESCRIPTION
Without path.join() if the data location in locations.js does
not have a trailing slash, darkroom comes back with an error like:

{"message":"ERROR: cannot open `/var/data/application/darkroom.testing.
clock.co.uk/imagesa478423a06a49c3d07c94d09c257a0f7/image'
(No such file or directory)"}

You can see that it is missing a slash after images and before the
image hash.
