### PR TITLE
Move GridFS config into locations.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ module.exports =
 , cache: './cache'
 , salt: 'salt'
 , key: 'key'
+, databaseUri: 'mongodb://localhost:27017/darkroom'
 }
 ```
 
@@ -71,7 +72,7 @@ Major refactor to include a GridFS backend option.
 
 This also drops the { src: 'HASH'} from upload responses. It has always been the same as `id`, so was removed.
 
-If you want to use a mongo backend add `databaseUri` to `config.js`
+If you want to use a mongo backend, set `databaseUri` in `locations.js`, otherwise set it to `false`.
 
 ```
 'databaseUri': 'mongodb://localhost:27017/darkroom'

--- a/config.js
+++ b/config.js
@@ -12,7 +12,7 @@ module.exports = function () {
     , 'log': true
     , quality: 85
     , apiProcesses: 1
-    //, 'databaseUri': 'mongodb://localhost:27017/darkroom'
+    , 'databaseUri': locations.databaseUri
     , paths:
       { 'data': function() { return locations.data }
       , 'cache': function() { return  locations.cache }

--- a/locations.js.tpl
+++ b/locations.js.tpl
@@ -3,4 +3,5 @@ module.exports =
 , cache: {CACHE}
 , salt: {SALT}
 , key: {KEY}
+, databaseUri: {DATABASE_URI}
 }


### PR DESCRIPTION
Configure `databaseUri` in `locations.js`, to keep consistency with other datastore options and facilitate configuration with Ansible role.
