### PR TITLE
Fix `Can't set headers after they are sent` error

### DIFF
--- a/endpoint/original.js
+++ b/endpoint/original.js
@@ -14,12 +14,12 @@ module.exports = function (config, backendFactory) {
         { 'Content-Type': meta.type
         , 'Content-Length': meta.size
         })
-      stream.on('notFound', function () {
-        next(new restify.ResourceNotFoundError('Not Found'))
-      })
-      stream.on('error', next)
 
       stream.pipe(res)
     })
+    stream.on('notFound', function () {
+      next(new restify.ResourceNotFoundError('Not Found'))
+    })
+    stream.on('error', next)
   }
 }


### PR DESCRIPTION
This error is caused by the stream's `meta` event taking too long to be
fired - if the send stream has started or finished, this will throw an
error when trying to set headers.
Waiting for the `meta` event before sending data is possible as both the
backends emit it once the file metadata has been acquired.