### PR TITLE
Bump verydarkroom version to the new version using gifsicle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN yarn global add pkg
 
 FROM microadam/graphicsmagick-alpine:1.3.28 AS release
 
-RUN apk add --update libstdc++ libgcc && rm -rf /var/cache/apk/*
+RUN apk add --update libstdc++ libgcc gifsicle && rm -rf /var/cache/apk/*
 
 WORKDIR /app
 COPY darkroom .

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Authentication between services and client will be achieved by using Oauth. This
     git clone git@github.com:clocklimited/Darkroom-api.git
     cd Darkroom-api
     nave usemain 0.10.40
-    brew install gm
+    brew install gm gifsicle
     npm install
 
 ## Ubuntu
-    sudo apt-get install graphicsmagick
+    sudo apt-get install graphicsmagick gifsicle
     git clone git@github.com:clocklimited/Darkroom-api.git
     cd Darkroom-api
     npm install
@@ -65,7 +65,15 @@ Or you can pass a given salt
 ./support/authed-cli /info/345e73295450e3aaf7d2b7a17258649c salty-salt
 ```
 
-# Version 6.8.0 (Current)
+# Version 7.0.0 (Current)
+
+This version adds support for optimised animated gifs using the `gifsicle` software package
+
+As a result, both darkroom and darkroom-api now require Gifsicle 1.88 or later for full functionality.
+
+Without it, you will be unable to process gif's uploaded to dark room
+
+# Version 6.8.0
 
 Adds a new `/download` endpoint to ensure the correct headers are sent to force a browser to download a file
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "darkroom-api",
   "private": true,
-  "version": "6.8.0",
+  "version": "7.0.0",
   "description": "Darkroom API for image manipulation",
   "main": "app.js",
   "dependencies": {
@@ -23,7 +23,7 @@
     "restify": "4.3.4",
     "rimraf": "^2.4.0",
     "temp": "^0.8.3",
-    "verydarkroom": "^4.6.0"
+    "verydarkroom": "^4.6.1"
   },
   "devDependencies": {
     "assert-diff": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2892,10 +2892,10 @@ verror@1.6.0:
   dependencies:
     extsprintf "1.2.0"
 
-verydarkroom@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/verydarkroom/-/verydarkroom-4.6.0.tgz#adb81ac366a0548625e2c40a90db1098800e8a26"
-  integrity sha512-QajZr4PrpE0e9ZXsdp7wh1Ft4PSfTyV0kPYWVDK4uukBQv0giIY5zW0hIDpi7FvXdv8GqPf+JvQAtjbxItPbgQ==
+verydarkroom@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/verydarkroom/-/verydarkroom-4.6.1.tgz#ac1748ee97e76088757e1e1875b1a64d8fefe7d2"
+  integrity sha512-/IJRJeybYRTqm2bVooMqafSVeb2zEHUBFJFXpzUz2nDW+hT1rVUyGCWV83Zhg28HGPkwDjP92mcfb2JOMmC8hg==
   dependencies:
     async "^2.6.1"
     file-type "^10.7.0"


### PR DESCRIPTION
When used with a Clock site currently using darkroom, this allows cropping images using the CMS crop feature without any glitchiness.

# CMS

![image](https://user-images.githubusercontent.com/581104/51268803-c4ec2d00-19b8-11e9-8f66-62a6fb844e72.png)

# Site 
![image](https://user-images.githubusercontent.com/581104/51268825-d03f5880-19b8-11e9-8264-1080687ca674.png)
