### PR TITLE
feat:(darkroom): Upgrades mmmagic dependency to enable node 12 on darkroom

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lodash.clone": "^4.0.1",
     "mime": "^1.3.4",
     "mkdirp": "^0.5.1",
-    "mmmagic": "^0.4.1",
+    "mmmagic": "^0.5.3",
     "mongodb": "^2.0.45",
     "mv": "^2.0.3",
     "pliers": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1982,11 +1982,12 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@0.x.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~
   dependencies:
     minimist "0.0.8"
 
-mmmagic@^0.4.1:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/mmmagic/-/mmmagic-0.4.6.tgz#5e2bcb88c4408164b77932339cb4326db37af235"
+mmmagic@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mmmagic/-/mmmagic-0.5.3.tgz#a28feb0cf85632fd6a1e233e4a584990ae0d7302"
+  integrity sha512-xLqCu7GJYTzJczg0jafXFuh+iPzQL/ru0YYf4GiTTz8Cehru/wiXtUS8Pp8Xi77zNaiVndJ0OO1yAFci6iHyFg==
   dependencies:
-    nan "^2.4.0"
+    nan "^2.13.2"
 
 mocha@^2.2.5:
   version "2.5.3"
@@ -2050,9 +2051,14 @@ mv@^2.0.3, mv@~2:
     ncp "~2.0.0"
     rimraf "~2.4.0"
 
-nan@^2.10.0, nan@^2.4.0, nan@^2.9.2:
+nan@^2.10.0, nan@^2.9.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
+
+nan@^2.13.2:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
+  integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
 natural-compare@~1.2.2:
   version "1.2.2"


### PR DESCRIPTION
****
**Project upgraded to run on Node v12**
****

****
**Necessary major upgrades**
****
- 'mmmagic' from 0.4.1 to 0.5.3 (node-gyp build errors) 

****
**Demo**
****
https://www.loom.com/share/ecfa97e848ae440489d43775f7b82b95
****
**Tests**
****
![Screen Shot 2020-04-29 at 10 35 52](https://user-images.githubusercontent.com/17994197/80581626-585a3d80-8a05-11ea-8589-e96b406ca1f0.png)


