### PR TITLE
feat(resize): adds quality as querystring option

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -506,6 +506,12 @@ Note, when running examples for image manipulation, make sure you've uploaded th
    | `height` | No | Specifies height of the new image. |
    | `mode` | No | One of `fit`, `stretch`, `cover`, `pad`. |
 
+* **Query Params**
+
+   | Param | Required | Usage |
+   |-------|----------|-------|
+   | `quality` | No | Specifies quality of the new image (excluded for PNGs). See [here](http://www.graphicsmagick.org/GraphicsMagick.html#details-quality)
+
 * **Header Params**
 
     None

--- a/endpoint/resize.js
+++ b/endpoint/resize.js
@@ -65,7 +65,7 @@ module.exports = function (serviceLocator, backendFactory) {
     readStream.pipe(resize).pipe(passThrough, {
       width: Number(width),
       height: Number(height),
-      quality: config.quality,
+      quality: req.query.quality || config.quality,
       mode,
       format
     })

--- a/lib/authorised.js
+++ b/lib/authorised.js
@@ -8,7 +8,8 @@ const allowedQuerystringProperties = [
   'height',
   'width',
   'colour',
-  'mode'
+  'mode',
+  'quality'
 ]
 const clone = require('lodash.clone')
 

--- a/test/authorised-middleware.test.js
+++ b/test/authorised-middleware.test.js
@@ -77,7 +77,8 @@ describe('Authorised middleware', function () {
         y1: '0',
         height: '100',
         width: '100',
-        colour: '#fff'
+        colour: '#fff',
+        quality: 80
       },
       qs = querystring.stringify(qsObject),
       baseUrl = '/circle/',

--- a/test/config.js
+++ b/test/config.js
@@ -20,7 +20,8 @@ module.exports = function () {
       version: '0.0.1',
       salt: 'salt',
       key: 'key',
-      allowedResponseFormats: ['png']
+      allowedResponseFormats: ['png'],
+      quality: 80
     }
   }
   if (process.env.MONGO_BACKEND)

--- a/test/hash-helper.js
+++ b/test/hash-helper.js
@@ -1,9 +1,9 @@
 const crypto = require('crypto')
 const config = require('con.figure')(require('./config')())
 
-module.exports = function (requestString) {
+module.exports = function (requestString, qs = '') {
   const md5sum = crypto.createHash('md5')
-  md5sum.update(requestString + config.salt)
+  md5sum.update(requestString + qs + config.salt)
 
   return md5sum.digest('hex')
 }

--- a/test/resize.test.js
+++ b/test/resize.test.js
@@ -203,6 +203,43 @@ backends().forEach(function (backend) {
         })
     })
 
+    it('should set quality based on querystring', function (done) {
+      var uri = '/160/' + imgSrcId,
+        qs = 'quality=60',
+        url = uri + ':' + hashHelper(uri, qs) + '?' + qs
+
+      config.allowedResponseFormats = allowedResponseFormats
+
+      request(darkroom)
+        .get(url)
+        .expect(200)
+        .end(function (error, res) {
+          if (error) return done(error)
+          gm(res.body).identify(function (err, data) {
+            assert.equal(data['JPEG-Quality'], '60')
+            done(err)
+          })
+        })
+    })
+
+    it('should set quality based on config if not provided by querystring', function (done) {
+      var uri = '/160/' + imgSrcId,
+        url = uri + ':' + hashHelper(uri)
+
+      config.allowedResponseFormats = allowedResponseFormats
+
+      request(darkroom)
+        .get(url)
+        .expect(200)
+        .end(function (error, res) {
+          if (error) return done(error)
+          gm(res.body).identify(function (err, data) {
+            assert.equal(data['JPEG-Quality'], config.quality)
+            done(err)
+          })
+        })
+    })
+
     describe('Cache Control Headers', function () {
       it('should return a high max age header of successful requests', function (done) {
         var uri = '/100/' + imgSrcId,


### PR DESCRIPTION
## What it does

Allows one to specify the quality of image that comes back from a resize, via the `quality` querystring parameter.

## Tests Written?

 - [x] Yes, I've been a good codeperson and written tests.

## Docs updated

<!-- Please ensure the docs accurately represent what the code does -->
<!-- See ./API_DOCUMENTATION.md -->

 - [x] Yes, I've been a good codeperson and updated the docs.

## Comments

There is already a precedence of querystring options in the `circle` endpoint.

See https://github.com/clocklimited/darkroom-url-builder/pull/1 for the dr-url-builder PR.

## Changelog Snippet

`Adds quality querystring parameter to resize`
