### PR TITLE
fix(response-format): should be able to specify response format with qs

### DIFF
--- a/lib/middleware/route-checker.js
+++ b/lib/middleware/route-checker.js
@@ -11,12 +11,12 @@ const createRouteChecker = (config) => {
     if (req.method !== 'GET') return next()
 
     if (Object.keys(req.params).length === 0) return next()
-    const dataPath = req.url
-    const tokens = dataPath.match(
-      /(http.*|[a-zA-Z0-9]{32,}):([a-zA-Z0-9]{32,})/
-    )
-    const extName = path.extname(req.url)
-    const hasQuery = extName.includes('?')
+    const tokens = req.url.match(/(http.*|[a-zA-Z0-9]{32,}):([a-zA-Z0-9]{32,})/)
+    let { base, ext } = path.parse(req.url)
+
+    if (base.startsWith('.') && !ext) ext = base
+
+    const hasQuery = ext.includes('?')
 
     // Error if an valid token is not found
     if (!Array.isArray(tokens) || tokens.length < 3) {
@@ -29,9 +29,7 @@ const createRouteChecker = (config) => {
     req.params.hash = tokens.shift()
     req.params.action = req.url.substring(0, req.url.indexOf(req.params.data))
     req.params.format = whitelistResponseFormat(
-      extName
-        .substring(1, hasQuery ? extName.indexOf('?') : undefined)
-        .toLowerCase()
+      ext.substring(1, hasQuery ? ext.indexOf('?') : undefined).toLowerCase()
     )
 
     if (authorised(req)) {

--- a/test/lib/middleware/route-checker.test.js
+++ b/test/lib/middleware/route-checker.test.js
@@ -106,7 +106,7 @@ describe('Route checker', () => {
     })
   })
 
-  it('should set req.params properties with format if provided', (done) => {
+  it('should set req.params.format if provided', (done) => {
     const checkRoute = createRouteChecker(config)
 
     const req = {
@@ -138,7 +138,7 @@ describe('Route checker', () => {
     })
   })
 
-  it('should set req.params properties with format even with querystring', (done) => {
+  it('should set req.params.format even there is a querystring', (done) => {
     const checkRoute = createRouteChecker(config)
 
     const req = {
@@ -154,6 +154,70 @@ describe('Route checker', () => {
         assert.strictEqual(
           value,
           '/160/1cfdd3bf942749472093f3b0ed6d4f89:93e7b6c489485692e96ec3de52c7a939/a.png?quality=100'
+        )
+      }
+    }
+    checkRoute(req, res, (error) => {
+      assert.ifError(error)
+      assert.deepStrictEqual(req.params, {
+        0: 160,
+        data: '1cfdd3bf942749472093f3b0ed6d4f89',
+        hash: '93e7b6c489485692e96ec3de52c7a939',
+        action: '/160/',
+        format: 'png'
+      })
+      done()
+    })
+  })
+
+  it('should set req.params.format when there is no file name before extension', (done) => {
+    const checkRoute = createRouteChecker(config)
+
+    const req = {
+      method: 'GET',
+      params: { 0: 160 },
+      query: {},
+      url:
+        '/160/1cfdd3bf942749472093f3b0ed6d4f89:93e7b6c489485692e96ec3de52c7a939/.png?quality=100'
+    }
+    const res = {
+      set: (header, value) => {
+        assert.strictEqual(header, 'Authorized-Request')
+        assert.strictEqual(
+          value,
+          '/160/1cfdd3bf942749472093f3b0ed6d4f89:93e7b6c489485692e96ec3de52c7a939/.png?quality=100'
+        )
+      }
+    }
+    checkRoute(req, res, (error) => {
+      assert.ifError(error)
+      assert.deepStrictEqual(req.params, {
+        0: 160,
+        data: '1cfdd3bf942749472093f3b0ed6d4f89',
+        hash: '93e7b6c489485692e96ec3de52c7a939',
+        action: '/160/',
+        format: 'png'
+      })
+      done()
+    })
+  })
+
+  it('should set req.params.format when there is no / before extension', (done) => {
+    const checkRoute = createRouteChecker(config)
+
+    const req = {
+      method: 'GET',
+      params: { 0: 160 },
+      query: {},
+      url:
+        '/160/1cfdd3bf942749472093f3b0ed6d4f89:93e7b6c489485692e96ec3de52c7a939.png?quality=100'
+    }
+    const res = {
+      set: (header, value) => {
+        assert.strictEqual(header, 'Authorized-Request')
+        assert.strictEqual(
+          value,
+          '/160/1cfdd3bf942749472093f3b0ed6d4f89:93e7b6c489485692e96ec3de52c7a939.png?quality=100'
         )
       }
     }


### PR DESCRIPTION
## What it does

Fixes response format when there is query string *and* makes setting a format works in more cases.

I've made sure we support `/id:checksum.jpg` and `/id:checksum/.jpg` urls for setting a format.

## Tests Written?

 - [x] Yes, I've been a good codeperson and written tests.

## Docs updated

No need, bug fix. 

## Comments

I have none.

## Changelog Snippet

`Fixes custom response format when querystring is provided.`
