### PR TITLE
feat(resize): exposes gravity as configurable

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -511,6 +511,7 @@ Note, when running examples for image manipulation, make sure you've uploaded th
    | Param | Required | Usage |
    |-------|----------|-------|
    | `quality` | No | Specifies quality of the new image (excluded for PNGs). See [here](http://www.graphicsmagick.org/GraphicsMagick.html#details-quality)
+   | `gravity` | No | Specifies the direction that the image gravitates, when using some fill modes. See [here](http://www.graphicsmagick.org/GraphicsMagick.html#details-gravity)
 
 * **Header Params**
 
@@ -715,7 +716,7 @@ Note, when running examples for image manipulation, make sure you've uploaded th
 
 * **Data Params**
 
-  Requires an image ID in `src`. Also accepts an array of masks, which if not provided will blur the 
+  Requires an image ID in `src`. Also accepts an array of masks, which if not provided will blur the
   whole image
 
   To control the amount of blur, add in an extra `blurAmount: 10`

--- a/endpoint/resize.js
+++ b/endpoint/resize.js
@@ -69,6 +69,7 @@ module.exports = function (serviceLocator, backendFactory) {
       width: Number(width),
       height: Number(height),
       quality: req.query.quality || config.quality,
+      gravity: req.query.gravity,
       mode,
       format
     })

--- a/lib/authorised.js
+++ b/lib/authorised.js
@@ -9,7 +9,8 @@ const allowedQuerystringProperties = [
   'width',
   'colour',
   'mode',
-  'quality'
+  'quality',
+  'gravity'
 ]
 const clone = require('lodash.clone')
 
@@ -31,6 +32,7 @@ module.exports = function (config) {
 
     md5sum.update(req.params.action + req.params.data + qs + config.salt)
     const hash = md5sum.digest('hex')
+
     return hash === req.params.hash
   }
 }

--- a/test/authorised-middleware.test.js
+++ b/test/authorised-middleware.test.js
@@ -78,7 +78,8 @@ describe('Authorised middleware', function () {
         height: '100',
         width: '100',
         colour: '#fff',
-        quality: 80
+        quality: 80,
+        gravity: 'South'
       },
       qs = querystring.stringify(qsObject),
       baseUrl = '/circle/',

--- a/test/resize.test.js
+++ b/test/resize.test.js
@@ -240,6 +240,49 @@ backends().forEach(function (backend) {
         })
     })
 
+    it('should accept gravity set in querystring', function (done) {
+      var uri = '/160/' + imgSrcId,
+        qs = 'gravity=South',
+        url = uri + ':' + hashHelper(uri, qs) + '?' + qs
+
+      config.allowedResponseFormats = allowedResponseFormats
+
+      request(darkroom)
+        .get(url)
+        .expect(200)
+        .end(function (error, res) {
+          if (error) return done(error)
+          gm(res.body).identify(function (err, data) {
+            assert.strictEqual(res.headers['d-cache'], 'MISS')
+            assert.strictEqual(data.size.width, 160)
+            assert.strictEqual(data.size.height, 120)
+            done(err)
+          })
+        })
+    })
+
+    it('should accept multiple querystring options', function (done) {
+      var uri = '/160/' + imgSrcId,
+        qs = 'quality=60&gravity=South',
+        url = uri + ':' + hashHelper(uri, qs) + '?' + qs
+
+      config.allowedResponseFormats = allowedResponseFormats
+
+      request(darkroom)
+        .get(url)
+        .expect(200)
+        .end(function (error, res) {
+          if (error) return done(error)
+          gm(res.body).identify(function (err, data) {
+            assert.strictEqual(res.headers['d-cache'], 'MISS')
+            assert.equal(data['JPEG-Quality'], 60)
+            assert.strictEqual(data.size.width, 160)
+            assert.strictEqual(data.size.height, 120)
+            done(err)
+          })
+        })
+    })
+
     describe('Cache Control Headers', function () {
       it('should return a high max age header of successful requests', function (done) {
         var uri = '/100/' + imgSrcId,


### PR DESCRIPTION
## What it does

Allows the gravity (the direction that the image gravitates to) to be configured on resize.

## Tests Written?

 - [x] Yes, I've been a good codeperson and written tests.

## Docs updated

 - [x] Yes, I've been a good codeperson and updated the docs.

## Comments

The GM gravity options are `NorthWest, North, NorthEast, West, Center, East, SouthWest, South, SouthEast`.

Backwards compatible.

Have an example:

### Original
![the-beatles](https://user-images.githubusercontent.com/1822529/138167030-ad4e35a6-0041-4d65-9c19-6bf13fcaffb6.jpg)

### Quality 100 (to prove multiple QS values work), Gravity West
![quality-100-gravity-west](https://user-images.githubusercontent.com/1822529/138167204-5b78ddea-5a29-4be5-ad3a-412db0ac2fb1.jpeg)

### Gravity East
![gravity-east](https://user-images.githubusercontent.com/1822529/138167401-2ba957c4-17a2-49b5-86be-f29c30d46895.jpeg)

### Gravity South
![gravity-south](https://user-images.githubusercontent.com/1822529/138167418-2217be2c-07e0-4a5a-93d8-097ca98d007a.jpeg)

### Gravity North
![gravity-north](https://user-images.githubusercontent.com/1822529/138167425-c7586c96-3a6a-41de-8077-6701ecc8fd68.jpeg)

### Default Gravity (default is and has been North for a long time)
![default-gravity](https://user-images.githubusercontent.com/1822529/138167435-edf5e0e4-f320-48f9-a797-e432f7d9dc9e.jpeg)


## Changelog Snippet

`Exposes gravity option for resize`.
