### PR TITLE
feat: Tell node how much heap it can used based on resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Version 12.2.0
+
+Revised entrypoint script to ensure that each clustered process can access the correct amount of memory for heap.
+
 ## Version 12.1.2
 
 Improve migration scripts (no functional changes).

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,5 @@ COPY locations.js.env locations.js
 
 RUN yarn install && yarn cache clean
 
-CMD ["node", "app.js"]
+ENTRYPOINT [ "/bin/sh", "run.sh" ]
+CMD [ "app.js"]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+if [ 0${MOSS} -gt 0 ]; then
+  echo "Setting max-old-space-size to ${MOSS}, based on env var"
+else
+  # max-old-space-size defaults, in case NF_ vars not present
+  MOSS_CPU=${NF_CPU_RESOURCES:-1}
+  MOSS_RAM=${NF_RAM_RESOURCES:-1400}
+
+  # If num CPUs is less than 1, round up.
+  case $MOSS_CPU in
+    "0."*) MOSS_CPU=1
+  esac
+
+  # Magic formula written by Jack Burgess.
+  MOSS=$(echo "$MOSS_RAM * 0.75 / $MOSS_CPU" | bc)
+
+  echo "Setting max-old-space-size to ${MOSS}, based on ${MOSS_CPU} CPU(s) and ${MOSS_RAM}MB RAM"
+fi
+
+exec node --max-old-space-size=${MOSS} "$@"
+


### PR DESCRIPTION

## What it does

<!-- What have you done? -->
Node runs with a default heap size of 1400MB
We run containers with various amounts of RAM
We should be using the maximum possible (when higher than default) We shouldn't be OOM killed (when lower than default) when trying to grow heap size We decided to share 75% of RAM between each forked process, since the option is passed to forked processes

![image](https://github.com/clocklimited/Darkroom-api/assets/6363719/0d23b176-6033-4796-976b-3366b08716b3)


## Tests Written?

 - [ ] Yes, I've been a good codeperson and written tests.

Not required

## Docs updated

<!-- Please ensure the docs accurately represent what the code does -->
<!-- See ./API_DOCUMENTATION.md -->

 - [ ] Yes, I've been a good codeperson and updated the docs.

Not required

## Comments

<!-- Is there a risk to deployments? Is it backwards compatible? -->
<!-- Do you need to do anything for deployment, scripts, etc? -->

Should be backwards compatible

## Changelog Snippet

<!-- Summarise your changes in one line for copy-paste to the changelog -->

updated already